### PR TITLE
feat: hideCorrelationIdInResponses parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ hpropagate({
 });
 ```
 
+- to hide the propagation of `x-correlation-id` in the response:
+
+```javascript
+hpropagate({
+    hideCorrelationIdInResponses: true
+});
+```
+
+
 ## The How
 
 Inspiration from this [talk](https://youtu.be/A2CqsR_1wyc?t=5h26m40s) ([Slides and Code](https://github.com/watson/talks/tree/master/2016/06%20NodeConf%20Oslo)) and this [module](https://github.com/guyguyon/node-request-context)

--- a/lib/config.js
+++ b/lib/config.js
@@ -28,6 +28,7 @@ const load = (overrides = {}) => {
       'x-b3-flags',
       'x-ot-span-context',
       'x-variant-id'],
+      hideCorrelationIdInResponses = false,
   } = overrides;
 
   validateHeaderList(headersToPropagate);
@@ -45,6 +46,7 @@ const load = (overrides = {}) => {
     correlationIdHeader,
     headersToCollect,
     headersToInject,
+    hideCorrelationIdInResponses,
   };
 };
 

--- a/lib/http_wrapper.js
+++ b/lib/http_wrapper.js
@@ -23,7 +23,10 @@ function setAndCollectCorrelationId(config, req, res) {
     correlationId = uuid.v4();
   }
   tracer.currentTrace.context.set(config.correlationIdHeader, correlationId);
-  res.setHeader(config.correlationIdHeader, correlationId);
+
+  if (!config.hideCorrelationIdInResponses) {
+    res.setHeader(config.correlationIdHeader, correlationId);
+  }
 }
 
 function collect(req, headers) {


### PR DESCRIPTION
`hpropagate` already support `propagateInResponses`, but the `x-correlation-id` always return in the response. This flag is `false` as default and can be used to omit the header